### PR TITLE
Remove duplicate field PrimaryValue from elasticsearch model.

### DIFF
--- a/aspnetcore/src/api/Models/Elasticsearch/ElasticsearchPublication.cs
+++ b/aspnetcore/src/api/Models/Elasticsearch/ElasticsearchPublication.cs
@@ -11,7 +11,6 @@ namespace api.Models.Elasticsearch
             PublicationYear = null;
             Doi = "";
             TypeCode = "";
-            PrimaryValue = null;
         }
 
         public string PublicationId { get; set; }
@@ -19,6 +18,5 @@ namespace api.Models.Elasticsearch
         public int? PublicationYear { get; set; }
         public string Doi { get; set; }
         public string TypeCode { get; set; }
-        public bool? PrimaryValue { get; set; }
     }
 }


### PR DESCRIPTION
Remove duplicate field PrimaryValue from elasticsearch model. It is already available in base class ElasticsearchItem.