### PR TITLE
Prevent inserting null value into dim_identifierless_data

### DIFF
--- a/aspnetcore/src/api/Services/OrcidImportService.cs
+++ b/aspnetcore/src/api/Services/OrcidImportService.cs
@@ -868,7 +868,7 @@ namespace api.Services
                 /*
                  * Affiliation department name handling
                  */
-                if (employment.DepartmentName != "")
+                if (!string.IsNullOrWhiteSpace(employment.DepartmentName))
                 {
                     // ORCID employment contains 'department-name'
 


### PR DESCRIPTION
Use IsNullOrWhiteSpace to check if affiliation department name is valid in ORCID import. This prevents inserting null value into dim_identifierless_data.