### PR TITLE
CSCTTV-3267 Populate fullName property

### DIFF
--- a/aspnetcore/src/api/Services/UserProfileService.cs
+++ b/aspnetcore/src/api/Services/UserProfileService.cs
@@ -1021,6 +1021,7 @@ namespace api.Services
                             {
                                 FirstNames = p.DimName_FirstNames,
                                 LastName = p.DimName_LastName,
+                                FullName = $"{p.DimName_LastName} {p.DimName_FirstNames}", // Populate for Elasticsearch queries
                                 itemMeta = new ProfileEditorItemMeta(
                                 
                                     id: p.FactFieldValues_DimNameId,


### PR DESCRIPTION
When first name and last name are known, populate property full name. This is needed in the Elasticsearch index to execute name searches in user profiles.