### PR TITLE
Handle settings endpoint error case, where user profile does not exist.

### DIFF
--- a/aspnetcore/src/api/Models/StructuredLog/LogContent.cs
+++ b/aspnetcore/src/api/Models/StructuredLog/LogContent.cs
@@ -36,6 +36,7 @@
             public const string ORCID_WEBHOOK_REGISTER = "ORCID: webhook: register";
             public const string ORCID_WEBHOOK_UNREGISTER = "ORCID: webhook: unregister";
             public const string ORCID_WEBHOOK_RECEIVED = "ORCID: webhook: received";
+            public const string SETTINGS_GET = "Settings: get";
         }
 
         public static class ActionState


### PR DESCRIPTION
Handle situation, where the profile settings endpoint is queried with a valid access token (user already in Keycloak), but the user profile does not yet exist in the database. 