### PR TITLE
Use ORCID Public API in test configuration

### DIFF
--- a/aspnetcore/src/api/Controllers/OrcidController.cs
+++ b/aspnetcore/src/api/Controllers/OrcidController.cs
@@ -85,7 +85,8 @@ namespace api.Controllers
 
             LogUserIdentification logUserIdentification = this.GetLogUserIdentification();
 
-            if (_webHostEnvironment.EnvironmentName!="Production" && this.GetOrcidPublicApiFlag() != null)
+            bool useOrcidPublicApi = _webHostEnvironment.EnvironmentName != "Production" && this.GetOrcidPublicApiFlag() != null;
+            if (useOrcidPublicApi)
             {
                 // ORCID public API should be used
                 try
@@ -263,7 +264,7 @@ namespace api.Controllers
                             .Include(ffv => ffv.DimProfileOnlyFundingDecision)
                             .Include(ffv => ffv.DimPidIdOrcidPutCodeNavigation).ToListAsync();
 
-                        await _orcidImportService.ImportAdditionalData(ffvs, orcidTokens.AccessToken);
+                        await _orcidImportService.ImportAdditionalData(factFieldValues: ffvs, orcidAccessToken: orcidTokens.AccessToken, useOrcidPublicApi: useOrcidPublicApi);
                         await localTtvContext.SaveChangesAsync();
 
                         _logger.LogInformation(

--- a/aspnetcore/src/api/Services/IOrcidApiService.cs
+++ b/aspnetcore/src/api/Services/IOrcidApiService.cs
@@ -9,6 +9,7 @@ namespace api.Services
         IConfiguration Configuration { get; }
 
         Task<string> GetDataFromMemberApi(String path, String orcidAccessToken);
+        Task<string> GetDataFromPublicApi(String path, String orcidAccessToken = "");
         string GetOrcidRecordPath(string orcidId);
         string GetOrcidWebhookAccessToken();
         string GetOrcidWebhookCallbackUri(string orcidId);

--- a/aspnetcore/src/api/Services/IOrcidImportService.cs
+++ b/aspnetcore/src/api/Services/IOrcidImportService.cs
@@ -8,6 +8,6 @@ namespace api.Services
     public interface IOrcidImportService
     {
         Task<bool> ImportOrcidRecordJsonIntoUserProfile(int userprofileId, string json);
-        Task<bool> ImportAdditionalData(List<FactFieldValue> factFieldValues, String orcidAccessToken);
+        Task<bool> ImportAdditionalData(List<FactFieldValue> factFieldValues, String orcidAccessToken, bool useOrcidPublicApi = false);
     }
 }

--- a/aspnetcore/src/api/Services/OrcidApiService.cs
+++ b/aspnetcore/src/api/Services/OrcidApiService.cs
@@ -191,7 +191,7 @@ namespace api.Services
         }
 
         /*
-         * 
+         * Get data from member API
          */
         public async Task<string> GetDataFromMemberApi(String path, String orcidAccessToken)
         {
@@ -205,6 +205,34 @@ namespace api.Services
             try
             {
                 HttpResponseMessage response = await orcidMemberApiHttpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"OrcidApiService: {ex.ToString()}");
+                return "";
+            }
+        }
+
+        /*
+         * Get data from public API
+         */
+        public async Task<string> GetDataFromPublicApi(String path, String orcidAccessToken="")
+        {
+            // Get ORCID public API specific http client.
+            HttpClient orcidPublicApiHttpClient = _httpClientFactory.CreateClient("ORCID_PUBLIC_API");
+            // GET request. Make sure "path" does not start with '/'
+            HttpRequestMessage request = new(method: HttpMethod.Get, requestUri: path.TrimStart('/'));
+            // Insert ORCID access token into authorization header for each request.
+            if (!string.IsNullOrWhiteSpace(orcidAccessToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", orcidAccessToken);
+            }
+            // Send request
+            try
+            {
+                HttpResponseMessage response = await orcidPublicApiHttpClient.SendAsync(request);
                 response.EnsureSuccessStatusCode();
                 return await response.Content.ReadAsStringAsync();
             }

--- a/aspnetcore/src/api/Services/OrcidImportService.cs
+++ b/aspnetcore/src/api/Services/OrcidImportService.cs
@@ -1756,13 +1756,21 @@ namespace api.Services
          * Implemented for:
          *   - fundings
          */
-        public async Task<bool> ImportAdditionalData(List<FactFieldValue> factFieldValues, String orcidAccessToken)
+        public async Task<bool> ImportAdditionalData(List<FactFieldValue> factFieldValues, String orcidAccessToken, bool useOrcidPublicApi=false)
         {
             foreach (FactFieldValue ffv in factFieldValues)
             {
                 if (ffv.DimProfileOnlyFundingDecisionId > 0)
                 {
-                    string result = await _orcidApiService.GetDataFromMemberApi(path: ffv.DimProfileOnlyFundingDecision.SourceDescription, orcidAccessToken: orcidAccessToken);
+                    string result = "";
+                    if (useOrcidPublicApi)
+                    {
+                        result = await _orcidApiService.GetDataFromPublicApi(path: ffv.DimProfileOnlyFundingDecision.SourceDescription, orcidAccessToken: orcidAccessToken);
+                    }
+                    else
+                    {
+                        result = await _orcidApiService.GetDataFromMemberApi(path: ffv.DimProfileOnlyFundingDecision.SourceDescription, orcidAccessToken: orcidAccessToken);
+                    }
                     OrcidFunding orcidFunding = _orcidJsonParserService.GetFundingDetail(fundingDetailJson: result);
 
                     ffv.DimProfileOnlyFundingDecision.OrcidWorkType = orcidFunding.Type;


### PR DESCRIPTION
In test configuration, get additional data from ORCID public API instead of member API.