### PR TITLE
Remove Moq NuGet package

### DIFF
--- a/aspnetcore/src/api.Tests/Services_Tests/OrcidApiServicetest.cs
+++ b/aspnetcore/src/api.Tests/Services_Tests/OrcidApiServicetest.cs
@@ -1,10 +1,7 @@
 using Xunit;
-using Moq;
 using api.Services;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
-using static System.Net.WebRequestMethods;
-using System.Security.Cryptography;
 using System.Collections;
 
 namespace api.Tests

--- a/aspnetcore/src/api.Tests/api.Tests.csproj
+++ b/aspnetcore/src/api.Tests/api.Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove Moq NuGet package because of security issue: https://snyk.io/blog/moq-package-exfiltrates-user-emails/